### PR TITLE
chore: add maintainers section in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,45 @@ This project is licensed under the GNU Affero General Public License v3.0 - see 
 - [Nuxt 3](https://nuxt.com/)
 - [Una UI](https://una-ui.vercel.app/)
 - [Schrödinger Hat](https://www.schrodinger-hat.it/)
+
+## Maintainers
+
+<div align="center">
+  <table>
+    <tr>
+      <td align="center">
+        <a href="https://github.com/TheJoin95">
+          <img src="https://github.com/TheJoin95.png" width="100px;" alt="Miki Lombardi"/>
+          <br />
+          <sub>
+            <b>Miki Lombardi</b>
+          </sub>
+        </a>
+        <br />
+        <span>💻 Maintainer</span>
+      </td>
+      <td align="center">
+        <a href="https://github.com/Readpato">
+          <img src="https://github.com/Readpato.png" width="100px;" alt="Patrick Raedler"/>
+          <br />
+          <sub>
+            <b>Patrick Raedler</b>
+          </sub>
+        </a>
+        <br />
+        <span>💻 Maintainer</span>
+      </td>
+      <td align="center">
+        <a href="https://github.com/MarcoJul">
+          <img src="https://github.com/MarcoJul.png" width="100px;" alt="Lorenzo Bugli"/>
+          <br />
+          <sub>
+            <b>Marco Giuliotti</b>
+          </sub>
+        </a>
+        <br />
+        <span>💻 Maintainer</span>
+      </td>
+    </tr>
+  </table>
+</div>


### PR DESCRIPTION
### 🔗 Linked issue

Refers and close #13

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds the maintainers section in the readme file

<img width="483" height="249" alt="image" src="https://github.com/user-attachments/assets/890b3911-4b75-480e-8ef1-8ebf7a4b36df" />


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
