### PR TITLE
feat: structured logging with request correlation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ contributors a shared, accurate picture of the system as it exists today.
 | [oauth-setup.md](./oauth-setup.md) | How to enable OAuth2/OIDC login (Google/GitHub/etc.) via Strapi's admin panel — documentation-only, not end-to-end tested |
 | [self-hosting.md](./self-hosting.md) | Deploying on your own domain: CORS allow-list env var, default admin credentials, uploads persistence, backup/restore, data export/import |
 | [monitoring.md](./monitoring.md) | `/api/health` and `/api/metrics` (Prometheus), Grafana starter dashboard |
+| [logging.md](./logging.md) | Structured JSON logging (`LOG_FORMAT_JSON`), per-request `X-Request-Id` correlation, shipping to Loki/ELK/Splunk |
 | [fresh-install-implementation.md](./fresh-install-implementation.md) | Pre-existing doc: how the fresh-install seed script works |
 
 ## How to use these docs

--- a/docs/known-issues-and-dev-notes.md
+++ b/docs/known-issues-and-dev-notes.md
@@ -354,3 +354,21 @@ backup/restore, and basic monitoring.
     (`server.initRouting()`) partway through its own `bootstrap()`, before
     this app's `bootstrap({ strapi })` hook ever runs. See
     [monitoring.md](./monitoring.md).
+
+29. **New: structured logging (`LOG_FORMAT_JSON`) with per-request
+    correlation.** Closes out the last open Enterprise Readiness item
+    (multi-tenancy remains deliberately deferred per item 5). New
+    `config/logger.ts` — Strapi's standard "every file in `config/` becomes
+    a config key" convention, no monkey-patching — switches from the default
+    colored `prettyPrint()` to `winston.format.json()` when
+    `LOG_FORMAT_JSON=true`, off by default so local dev is unaffected. A new
+    `src/middlewares/request-id.ts` (`global::request-id`, first in
+    `config/middlewares.ts` so its context covers the whole request
+    lifecycle) assigns a correlation id per request and runs the rest of the
+    chain inside an `AsyncLocalStorage` context
+    (`src/utils/request-context.ts`); `config/logger.ts`'s format reads that
+    same store and attaches `requestId` to **every** log line produced
+    during the request — including `strapi::logger`'s own access-log line —
+    with no changes needed to any of the ~40 existing `strapi.log.*()` call
+    sites (item 20's single-interpolated-string convention is untouched).
+    See [logging.md](./logging.md).

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,62 @@
+# Logging
+
+Off by default: local dev keeps Strapi's own colored console output
+(`prettyPrint()`) untouched. Set `LOG_FORMAT_JSON=true` to switch to
+structured JSON, meant for production/self-hosted deployments piping logs to
+Loki, ELK, or Splunk.
+
+## What changes
+
+`config/logger.ts` is picked up automatically by Strapi (same convention as
+`config/database.ts`) and, when `LOG_FORMAT_JSON=true`, replaces the default
+format with `winston.format.json()` plus a `timestamp` field and Error
+`stack` capture. Every log line — including the built-in access log
+(`GET /api/credentials (12 ms) 200`) and any `strapi.log.*()` call anywhere
+in the app — comes out as one JSON object, e.g.:
+
+```json
+{"level":"http","message":"GET /api/credentials (12 ms) 200","timestamp":"2026-08-05T10:00:00.000Z","requestId":"3f2a1c4e-..."}
+```
+
+## Request correlation (`X-Request-Id`)
+
+`src/middlewares/request-id.ts` assigns a correlation id to every request —
+reusing an incoming `X-Request-Id` header from your reverse proxy if
+present, generating a UUID otherwise — and echoes it back as a response
+header. `config/logger.ts`'s format attaches that same id to every log line
+produced during that request (via `src/utils/request-context.ts`'s
+`AsyncLocalStorage`), so you can grep/join a single request's log lines
+across a `strapi::logger` access-log entry and any deeper `strapi.log.*()`
+calls it triggered — without any of the ~40 existing call sites needing to
+change.
+
+## Shipping logs
+
+Since output goes to stdout either way (winston's default `Console`
+transport), any log shipper that tails container stdout works unmodified —
+Filebeat, Fluentd/Fluent Bit, Promtail, or your platform's own log
+collection. Example Promtail scrape config (assuming Docker's JSON-file log
+driver):
+
+```yaml
+scrape_configs:
+  - job_name: certo-backend
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+    pipeline_stages:
+      - json:
+          expressions:
+            level: level
+            requestId: requestId
+```
+
+## A note on extra log arguments
+
+`docs/known-issues-and-dev-notes.md` (item 20) documented that Strapi's
+default `prettyPrint()` format only reads `info.message` — a second object
+argument passed to `strapi.log.warn('message', { extra: 'data' })` is
+silently dropped. `winston.format.json()` doesn't have that limitation
+(winston merges a plain-object second argument into the logged object), so
+in JSON mode any such call sites will actually surface that metadata. This
+doc doesn't change any existing call sites — it's just worth knowing the
+two formats behave differently here if you add a new one.

--- a/src/backend/.env.example
+++ b/src/backend/.env.example
@@ -32,3 +32,9 @@ SMTP_REPLY_TO=
 # config/middlewares.ts. Only needed for self-hosted deployments.
 # e.g. CORS_ALLOWED_ORIGINS=https://badges.example.org,https://api.badges.example.org
 CORS_ALLOWED_ORIGINS=
+
+# Logging - set to true to emit structured JSON logs (with a per-request
+# requestId) instead of the default colored console output. Meant for
+# production/self-hosted deployments piping logs to Loki/ELK/Splunk - see
+# docs/logging.md. Leave unset for local dev.
+LOG_FORMAT_JSON=

--- a/src/backend/config/__tests__/logger.test.ts
+++ b/src/backend/config/__tests__/logger.test.ts
@@ -1,0 +1,68 @@
+import winston from 'winston'
+import { Writable } from 'node:stream'
+import loggerConfig from '../logger'
+import { requestContextStorage } from '../../src/utils/request-context'
+
+function createCapturingStream(lines: string[]) {
+  return new Writable({
+    write(chunk, _encoding, callback) {
+      lines.push(chunk.toString())
+      callback()
+    },
+  })
+}
+
+function buildConfig(logFormatJson: boolean) {
+  return (loggerConfig as any)({
+    env: {
+      bool: (_key: string, defaultValue: boolean) => logFormatJson ?? defaultValue,
+    },
+  })
+}
+
+describe('config/logger', () => {
+  it('returns an empty config (Strapi default prettyPrint) when LOG_FORMAT_JSON is not enabled', () => {
+    expect(buildConfig(false)).toEqual({})
+  })
+
+  it('returns a JSON format producing valid, parseable log lines when LOG_FORMAT_JSON is enabled', async () => {
+    const config = buildConfig(true)
+    expect(config.format).toBeDefined()
+
+    const lines: string[] = []
+    const logger = winston.createLogger({
+      format: config.format,
+      transports: [
+        new winston.transports.Stream({ stream: createCapturingStream(lines) }),
+      ],
+    })
+
+    logger.info('hello world')
+
+    expect(lines).toHaveLength(1)
+    const parsed = JSON.parse(lines[0])
+    expect(parsed.message).toBe('hello world')
+    expect(parsed.level).toBe('info')
+    expect(typeof parsed.timestamp).toBe('string')
+  })
+
+  it('includes requestId in the JSON output when logged inside a request context', async () => {
+    const config = buildConfig(true)
+    const lines: string[] = []
+    const logger = winston.createLogger({
+      format: config.format,
+      transports: [
+        new winston.transports.Stream({ stream: createCapturingStream(lines) }),
+      ],
+    })
+
+    await requestContextStorage.run({ requestId: 'req-42' }, async () => {
+      logger.info('inside a request')
+    })
+    logger.info('outside any request')
+
+    const [withinRequest, outsideRequest] = lines.map((line) => JSON.parse(line))
+    expect(withinRequest.requestId).toBe('req-42')
+    expect(outsideRequest.requestId).toBeUndefined()
+  })
+})

--- a/src/backend/config/logger.ts
+++ b/src/backend/config/logger.ts
@@ -1,0 +1,32 @@
+import winston from 'winston';
+import { getRequestId } from '../src/utils/request-context';
+
+// Attaches the current request's correlation id (see
+// src/middlewares/request-id.ts) to every log line produced during that
+// request's async execution - no changes needed to any individual
+// strapi.log.*() call site.
+const withRequestId = winston.format((info) => {
+  const requestId = getRequestId();
+  if (requestId) {
+    info.requestId = requestId;
+  }
+  return info;
+});
+
+// Structured JSON logging for production/self-hosted deployments piping
+// logs to Loki/ELK/Splunk - see docs/logging.md. Off by default: local dev
+// keeps Strapi's own colored console prettyPrint() output untouched.
+export default ({ env }) => {
+  if (!env.bool('LOG_FORMAT_JSON', false)) {
+    return {};
+  }
+
+  return {
+    format: winston.format.combine(
+      withRequestId(),
+      winston.format.timestamp(),
+      winston.format.errors({ stack: true }),
+      winston.format.json()
+    ),
+  };
+};

--- a/src/backend/config/middlewares.ts
+++ b/src/backend/config/middlewares.ts
@@ -30,6 +30,10 @@ export default ({ env }) => {
     /^https:\/\/deploy-preview-\d+--certo\.netlify\.app$/.test(origin);
 
   return [
+    // First, so its AsyncLocalStorage context covers the entire request
+    // lifecycle - including whatever strapi::errors catches. See
+    // src/middlewares/request-id.ts and config/logger.ts.
+    'global::request-id',
     'strapi::errors',
     {
       name: 'strapi::security',

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -21,7 +21,8 @@
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.0.0",
-        "styled-components": "^6.0.0"
+        "styled-components": "^6.0.0",
+        "winston": "^3.19.0"
       },
       "devDependencies": {
         "@babel/core": "^7.29.7",
@@ -1950,11 +1951,12 @@
       }
     },
     "node_modules/@dabh/diagnostics": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.3.tgz",
-      "integrity": "sha512-hrlQOIi7hAfzsMqlGSFyVucrx38O+j6wiGOf//H2ecvIEqYN4ADBSS2iLMh5UFyDunCNniUIPk/q3riFv45xRA==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "license": "MIT",
       "dependencies": {
-        "colorspace": "1.1.x",
+        "@so-ric/colorspace": "^1.1.6",
         "enabled": "2.0.x",
         "kuler": "^2.0.0"
       }
@@ -5757,6 +5759,62 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color-name": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.1.tgz",
+      "integrity": "sha512-p2FdgwVx1a9yWBHP2wI0VgShkDpgN4kZISkxdNipGBJWpa5G6b04OINlVWCyJj0JmfvcPrgqt95E9k8yvaOJFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/@so-ric/colorspace/node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@strapi/admin": {
       "version": "5.15.0",
       "resolved": "https://registry.npmjs.org/@strapi/admin/-/admin-5.15.0.tgz",
@@ -6311,6 +6369,51 @@
       "engines": {
         "node": ">=18.0.0 <=22.x.x",
         "npm": ">=6.0.0"
+      }
+    },
+    "node_modules/@strapi/logger/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@strapi/logger/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/@strapi/logger/node_modules/winston": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
+      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.5.0",
+        "@dabh/diagnostics": "^2.0.2",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.4.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.5.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/@strapi/permissions": {
@@ -9945,37 +10048,6 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
     },
-    "node_modules/colorspace": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/colorspace/-/colorspace-1.1.4.tgz",
-      "integrity": "sha512-BgvKJiuVu1igBUF2kEjRCZXol6wiiGbY5ipL/oVPwm0BL9sIpMIzM8IK7vwuxIIzOXMV3Ey5w+vxhm0rR/TN8w==",
-      "dependencies": {
-        "color": "^3.1.3",
-        "text-hex": "1.0.x"
-      }
-    },
-    "node_modules/colorspace/node_modules/color": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.2.1.tgz",
-      "integrity": "sha512-aBl7dZI9ENN6fUGC7mWpMTPNHmWUSNan9tuWN6ahh5ZLNk9baLJOnSMlrQkHcrfFgz2/RigjUVAjdx36VcemKA==",
-      "dependencies": {
-        "color-convert": "^1.9.3",
-        "color-string": "^1.6.0"
-      }
-    },
-    "node_modules/colorspace/node_modules/color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dependencies": {
-        "color-name": "1.1.3"
-      }
-    },
-    "node_modules/colorspace/node_modules/color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
-    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -11011,7 +11083,8 @@
     "node_modules/enabled": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
-      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ=="
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "license": "MIT"
     },
     "node_modules/encodeurl": {
       "version": "1.0.2",
@@ -15188,7 +15261,8 @@
     "node_modules/kuler": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
-      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A=="
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "license": "MIT"
     },
     "node_modules/leven": {
       "version": "3.1.0",
@@ -20393,7 +20467,8 @@
     "node_modules/text-hex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
-      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg=="
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "license": "MIT"
     },
     "node_modules/thenify": {
       "version": "3.3.1",
@@ -21888,21 +21963,22 @@
       }
     },
     "node_modules/winston": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-3.10.0.tgz",
-      "integrity": "sha512-nT6SIDaE9B7ZRO0u3UvdrimG0HkB7dSTAgInQnNR2SOPJ4bvq5q79+pXLftKmP52lJGW15+H5MCK0nM9D3KB/g==",
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "license": "MIT",
       "dependencies": {
-        "@colors/colors": "1.5.0",
-        "@dabh/diagnostics": "^2.0.2",
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
         "async": "^3.2.3",
         "is-stream": "^2.0.0",
-        "logform": "^2.4.0",
+        "logform": "^2.7.0",
         "one-time": "^1.0.0",
         "readable-stream": "^3.4.0",
         "safe-stable-stringify": "^2.3.1",
         "stack-trace": "0.0.x",
         "triple-beam": "^1.3.0",
-        "winston-transport": "^4.5.0"
+        "winston-transport": "^4.9.0"
       },
       "engines": {
         "node": ">= 12.0.0"
@@ -21940,6 +22016,15 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/winston/node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/winston/node_modules/readable-stream": {

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -31,7 +31,8 @@
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",
-    "styled-components": "^6.0.0"
+    "styled-components": "^6.0.0",
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/src/backend/src/middlewares/__tests__/request-id.test.ts
+++ b/src/backend/src/middlewares/__tests__/request-id.test.ts
@@ -1,0 +1,47 @@
+import requestIdMiddlewareFactory from '../request-id'
+import { getRequestId } from '../../utils/request-context'
+
+function createFakeCtx(headers: Record<string, string> = {}) {
+  const responseHeaders: Record<string, string> = {}
+  return {
+    request: { header: headers },
+    state: {} as any,
+    set: (key: string, value: string) => { responseHeaders[key] = value },
+    responseHeaders,
+  }
+}
+
+describe('request-id middleware', () => {
+  it('generates a UUID when there is no incoming X-Request-Id header', async () => {
+    const middleware = requestIdMiddlewareFactory()
+    const ctx = createFakeCtx()
+
+    await middleware(ctx, async () => {})
+
+    expect(ctx.state.requestId).toMatch(/^[0-9a-f-]{36}$/)
+    expect(ctx.responseHeaders['X-Request-Id']).toBe(ctx.state.requestId)
+  })
+
+  it('reuses an incoming X-Request-Id header as-is', async () => {
+    const middleware = requestIdMiddlewareFactory()
+    const ctx = createFakeCtx({ 'x-request-id': 'upstream-provided-id' })
+
+    await middleware(ctx, async () => {})
+
+    expect(ctx.state.requestId).toBe('upstream-provided-id')
+    expect(ctx.responseHeaders['X-Request-Id']).toBe('upstream-provided-id')
+  })
+
+  it('makes the requestId available via getRequestId() inside next()', async () => {
+    const middleware = requestIdMiddlewareFactory()
+    const ctx = createFakeCtx({ 'x-request-id': 'inside-next-id' })
+    let seenInsideNext: string | undefined
+
+    await middleware(ctx, async () => {
+      seenInsideNext = getRequestId()
+    })
+
+    expect(seenInsideNext).toBe('inside-next-id')
+    expect(getRequestId()).toBeUndefined()
+  })
+})

--- a/src/backend/src/middlewares/request-id.ts
+++ b/src/backend/src/middlewares/request-id.ts
@@ -1,0 +1,27 @@
+/**
+ * Assigns a correlation id to every request (reusing an incoming
+ * `X-Request-Id` from a reverse proxy if present, generating one otherwise),
+ * echoes it back as a response header, and runs the rest of the middleware
+ * chain inside requestContextStorage.run() so config/logger.ts's format can
+ * attach it to every log line produced during this request - including
+ * strapi::logger's own access-log line - with no changes needed to any of
+ * the existing strapi.log.*() call sites elsewhere in the app.
+ *
+ * Registered as 'global::request-id', positioned first in
+ * config/middlewares.ts (before strapi::errors) so the async context covers
+ * the entire request lifecycle.
+ */
+import { randomUUID } from 'node:crypto';
+import { requestContextStorage } from '../utils/request-context';
+
+export default () => {
+  return async (ctx: any, next: any) => {
+    const incoming = ctx.request.header['x-request-id'];
+    const requestId = (Array.isArray(incoming) ? incoming[0] : incoming) || randomUUID();
+
+    ctx.state.requestId = requestId;
+    ctx.set('X-Request-Id', requestId);
+
+    await requestContextStorage.run({ requestId }, next);
+  };
+};

--- a/src/backend/src/utils/__tests__/request-context.test.ts
+++ b/src/backend/src/utils/__tests__/request-context.test.ts
@@ -1,0 +1,41 @@
+import { requestContextStorage, getRequestId } from '../request-context'
+
+describe('request-context', () => {
+  it('returns undefined outside any run() context', () => {
+    expect(getRequestId()).toBeUndefined()
+  })
+
+  it('returns the requestId inside a run() context', async () => {
+    await requestContextStorage.run({ requestId: 'abc-123' }, async () => {
+      expect(getRequestId()).toBe('abc-123')
+    })
+  })
+
+  it('is undefined again after the run() context ends', async () => {
+    await requestContextStorage.run({ requestId: 'abc-123' }, async () => {})
+    expect(getRequestId()).toBeUndefined()
+  })
+
+  it('isolates concurrent/overlapping contexts from each other', async () => {
+    const seenInsideA: (string | undefined)[] = []
+    const seenInsideB: (string | undefined)[] = []
+
+    const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+    await Promise.all([
+      requestContextStorage.run({ requestId: 'request-a' }, async () => {
+        seenInsideA.push(getRequestId())
+        await delay(10)
+        seenInsideA.push(getRequestId())
+      }),
+      requestContextStorage.run({ requestId: 'request-b' }, async () => {
+        seenInsideB.push(getRequestId())
+        await delay(5)
+        seenInsideB.push(getRequestId())
+      }),
+    ])
+
+    expect(seenInsideA).toEqual(['request-a', 'request-a'])
+    expect(seenInsideB).toEqual(['request-b', 'request-b'])
+  })
+})

--- a/src/backend/src/utils/request-context.ts
+++ b/src/backend/src/utils/request-context.ts
@@ -1,0 +1,20 @@
+/**
+ * Per-request correlation id, made available to any code running within a
+ * request's async execution (controllers, services, the winston format in
+ * config/logger.ts) without threading it through every function call or
+ * touching the ~40 existing `strapi.log.*()` call sites across the app.
+ *
+ * Populated by middlewares/request-id.ts, which wraps the rest of the
+ * middleware chain in `requestContextStorage.run(...)`.
+ */
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+interface RequestContext {
+  requestId: string;
+}
+
+export const requestContextStorage = new AsyncLocalStorage<RequestContext>();
+
+export function getRequestId(): string | undefined {
+  return requestContextStorage.getStore()?.requestId;
+}


### PR DESCRIPTION
Closes out the last open Enterprise Readiness item (multi-tenancy stays deliberately deferred). config/logger.ts switches to JSON output behind LOG_FORMAT_JSON, off by default so local dev is unaffected. A new request-id middleware plus an AsyncLocalStorage-backed request context attaches a correlation id to every log line produced during a request - including Strapi's own access-log line - without touching any of the existing strapi.log.*() call sites.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the code of conduct before creating a pull request
 👉 https://www.schroedinger-hat.org/code-of-conduct
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
