### PR TITLE
fix: secucrity and permission issue

### DIFF
--- a/docs/known-issues-and-dev-notes.md
+++ b/docs/known-issues-and-dev-notes.md
@@ -42,25 +42,30 @@ several of them are the kind of thing that tends to silently regress.
    `ENCRYPTION_KEY` itself has the same "make sure production generates its
    own, don't reuse the dev default" caveat the old key had.
 
-4. **External-credential proof verification is still a stub.**
-   `open-badge.ts`'s `validateExternalCredential()` sets
-   `const proofVerified = true` unconditionally — importing/validating a
-   third-party OBv3 credential doesn't check its signature. Deliberately not
-   addressed here: that work covers *our own* issuers' keys; verifying
-   an arbitrary external issuer needs DID resolution or fetching a remote
-   key, a separate, larger interoperability feature.
+4. **[Fixed] External-credential proof verification is now
+   cryptographic.** `open-badge.ts`'s `validateExternalCredential()` no
+   longer sets `const proofVerified = true` unconditionally. It now calls
+   `verifyExternalProof()`, which resolves the issuer's verification method
+   (local profile URL, remote HTTP(S) key document, or `did:web`/`did:key`),
+   fetches the public key, and cryptographically verifies the JWS signature
+   with `jose.jwtVerify`. See [open-badges.md](./open-badges.md#verification)
+   and Phase 1 of [roadmap.md](./roadmap.md).
 
-5. **Several controller actions bypass Strapi's permission system in code**
-   rather than through the role/permission model — e.g. `credential.issue` sets
+5. **[Fixed] Controller actions no longer bypass Strapi's permission
+   system in code.** `credential.issue` no longer sets
    `ctx.state.auth = { strategy: { name: 'public' } }` to disable the auth
-   check, and `achievement.create` calls `entityService` directly to bypass
-   permission checks. Don't assume permissions shown in the Strapi admin UI
-   fully describe what's actually enforced. **[Partially mitigated]**
-   these three actions (`credential.issue`, `credential.revoke`,
-   `achievement.create`) now record an `audit-log-entry` with the real
-   caller's user ID, so "who did this" is at least recoverable after the
-   fact even though the permission bypass itself is unchanged — see
-   [security.md](./security.md#authorization).
+   check — auth is enforced by the route config instead (mutating routes
+   use users-permissions). `achievement.create` and `createAchievement`
+   now call `super.create(ctx)` through the core controller (which enforces
+   Strapi RBAC) rather than calling `strapi.entityService.create()` directly
+   to bypass permission checks. All three actions continue to record an
+   `audit-log-entry` with the real caller's user ID, so "who did this" is
+   recoverable — see [security.md](./security.md#authorization).
+   Audit log coverage was also expanded (Aug 2026) to include
+   `credential.import`, `credential.import-open-badge`,
+   `credential.batch-issue`, `credential.renew`, `achievement.delete`,
+   and `profile.delete-data` (GDPR erasure) — see Phase 1 of
+   [roadmap.md](./roadmap.md).
 
 6. **[Fixed] Revocation lists are now wired into issuance,
    revocation, serialization, and verification.** Previously the entire

--- a/helm/certo/templates/backup-cronjob.yaml
+++ b/helm/certo/templates/backup-cronjob.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.backup.enabled }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "certo.fullname" . }}-backup
+  labels:
+    {{- include "certo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  # Daily backup at 02:00 UTC by default. Override with
+  # `--set backup.schedule="0 3 * * *"`.
+  schedule: {{ .Values.backup.schedule | default "0 2 * * *" | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: OnFailure
+          containers:
+            - name: backup
+              image: "{{ .Values.backend.image.repository }}:{{ .Values.backend.image.tag }}"
+              imagePullPolicy: {{ .Values.backend.image.pullPolicy }}
+              command: ["npm", "run", "backup"]
+              envFrom:
+                - secretRef:
+                    name: {{ include "certo.secretName" . }}
+              env:
+                {{- if .Values.postgresql.enabled }}
+                - name: DATABASE_CLIENT
+                  value: "postgres"
+                - name: DATABASE_HOST
+                  value: {{ include "certo.postgresql.fullname" . | quote }}
+                - name: DATABASE_PORT
+                  value: "5432"
+                - name: DATABASE_NAME
+                  value: {{ .Values.postgresql.database | quote }}
+                - name: DATABASE_USERNAME
+                  value: {{ .Values.postgresql.username | quote }}
+                {{- else if .Values.postgresql.external.host }}
+                - name: DATABASE_CLIENT
+                  value: "postgres"
+                - name: DATABASE_HOST
+                  value: {{ .Values.postgresql.external.host | quote }}
+                - name: DATABASE_PORT
+                  value: {{ .Values.postgresql.external.port | quote }}
+                - name: DATABASE_NAME
+                  value: {{ .Values.postgresql.database | quote }}
+                - name: DATABASE_USERNAME
+                  value: {{ .Values.postgresql.username | quote }}
+                {{- else }}
+                - name: DATABASE_CLIENT
+                  value: "sqlite"
+                {{- end }}
+                {{- if .Values.backup.retentionDays }}
+                - name: BACKUP_RETENTION_DAYS
+                  value: {{ .Values.backup.retentionDays | quote }}
+                {{- end }}
+              volumeMounts:
+                - name: backup-data
+                  mountPath: /app/backups
+                {{- if .Values.backend.uploads.enabled }}
+                - name: uploads-data
+                  mountPath: /app/public/uploads
+                {{- end }}
+              resources:
+                {{- toYaml .Values.backend.resources | nindent 16 }}
+          volumes:
+            - name: backup-data
+              persistentVolumeClaim:
+                claimName: {{ include "certo.fullname" . }}-backup
+            {{- if .Values.backend.uploads.enabled }}
+            - name: uploads-data
+              persistentVolumeClaim:
+                claimName: {{ include "certo.backend.fullname" . }}-uploads
+            {{- end }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "certo.fullname" . }}-backup
+  labels:
+    {{- include "certo.labels" . | nindent 4 }}
+    app.kubernetes.io/component: backup
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.backup.storageClassName }}
+  storageClassName: {{ .Values.backup.storageClassName }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.backup.size | default "10Gi" }}
+{{- end }}

--- a/helm/certo/values.yaml
+++ b/helm/certo/values.yaml
@@ -85,6 +85,19 @@ secrets:
   # long-lived secret.
   encryptionKey: ""
 
+# Scheduled backups via a Kubernetes CronJob (daily by default). Runs
+# `npm run backup` in the backend image, mounting a dedicated PVC; see
+# templates/backup-cronjob.yaml. Disabled by default — enable for
+# production. Schedule is standard cron syntax (UTC).
+backup:
+  enabled: false
+  schedule: "0 2 * * *"
+  size: 10Gi
+  storageClassName: ""
+  # Optional: keep only the last N days of backups. Leave empty to keep
+  # all backups.
+  retentionDays: ""
+
 # Bundled Postgres: a plain StatefulSet + PVC, suitable for testing/small
 # deployments - NOT horizontally scalable and not a replacement for a real
 # managed Postgres in production. Set enabled: false and fill in `external`

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine
+FROM node:22-alpine
 
 # Set working directory
 WORKDIR /app

--- a/src/backend/config/middlewares.ts
+++ b/src/backend/config/middlewares.ts
@@ -37,6 +37,9 @@ export default ({ env }) => {
     // lifecycle - including whatever strapi::errors catches. See
     // src/middlewares/request-id.ts and config/logger.ts.
     'global::request-id',
+    // Rate limiting & brute-force protection on auth endpoints.
+    // See src/middlewares/rate-limit.ts.
+    'global::rate-limit',
     'strapi::errors',
     {
       name: 'strapi::security',

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -18,6 +18,7 @@
         "better-sqlite3": "11.3.0",
         "dotenv": "^16.6.1",
         "jose": "^6.0.11",
+        "otplib": "^13.4.1",
         "prom-client": "^15.1.3",
         "qrcode": "^1.5.4",
         "react": "^18.0.0",
@@ -33,7 +34,7 @@
         "@babel/core": "^7.29.7",
         "@babel/preset-env": "^7.29.7",
         "@types/jest": "^30.0.0",
-        "@types/node": "^20",
+        "@types/node": "^22",
         "@types/qrcode": "^1.5.6",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -43,7 +44,7 @@
         "typescript": "^5"
       },
       "engines": {
-        "node": ">=18.0.0 <=22.x.x",
+        "node": ">=22.0.0",
         "npm": ">=6.0.0"
       }
     },
@@ -4880,6 +4881,74 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/@otplib/core": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-13.4.1.tgz",
+      "integrity": "sha512-KIXgK1hNtWJEBMTastbe1bpmuais+3f+ATeO8TkMs2rNkfGO1FbQy8+/UWVEu3TR/iTJerU0idkPudaPmLP2BA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/hotp": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/hotp/-/hotp-13.4.1.tgz",
+      "integrity": "sha512-g9q04SwpG5ZtMnVkUcgcoAlwCH4YLROZN1qhyBwgkBzqYYVSYhpP6gSGaxGHwePLt1c+e6NqDlgIZN+e1/XPuA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/plugin-base32-scure": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-base32-scure/-/plugin-base32-scure-13.4.1.tgz",
+      "integrity": "sha512-Fs/r5qisC05SRhT6xWXaypB6PVC0vgWf6zztmi0J5RnQ09OJiPDWCJFH6cDm6ANsrdvB9di7X+Jb7L13BoEbUA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@scure/base": "^2.2.0"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto-noble/-/plugin-crypto-noble-13.4.1.tgz",
+      "integrity": "sha512-PJfVW8/1hdS6CfxLheKPZSLTwDq4TijZbN4yRjxlv0ODdzmxpM+wGwWr1JXMdy0xJPxLziydQD5gdVqrR4/gAg==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^2.2.0",
+        "@otplib/core": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/plugin-crypto-noble/node_modules/@noble/hashes": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.3.0.tgz",
+      "integrity": "sha512-oN+QwyX7VSHotibwubG3kpzbwKrfnyR6OOO+3Nk/53ADL7FmgHHz4TgrbaYKvvOw09u6QTx0oiH1cNCIOuN0CQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.19.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@otplib/totp": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/totp/-/totp-13.4.1.tgz",
+      "integrity": "sha512-QOkBVPrf6AM4qZaReZPSk9/I8ATVdZpIISJz115MqeVtcrbcr5llPZ0J7804tpnjnp1vCRkI5Qjd47HhgVteBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/hotp": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
+    "node_modules/@otplib/uri": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/@otplib/uri/-/uri-13.4.1.tgz",
+      "integrity": "sha512-xaIm7bvICMhoB2rZIR5luiaMdssWR5nY5nXnR1fdezUgZuEO58D6zrGzLp7pQuBmlpmL0HagnscDQFoskp9yiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
@@ -6559,6 +6628,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/@scure/base": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-2.3.0.tgz",
+      "integrity": "sha512-NsG6Y03tY6R5BUis4FdVtHVkur0U6FOzskgs9ZXNl78CUc9fkZ78HmENUle1nSOkCasDmbubmWD9qwB7mm4PZA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
     },
     "node_modules/@simov/deep-extend": {
       "version": "1.0.0",
@@ -8943,11 +9021,12 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="
     },
     "node_modules/@types/node": {
-      "version": "20.17.57",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.57.tgz",
-      "integrity": "sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==",
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.19.2"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/nodemon": {
@@ -18077,6 +18156,20 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/otplib": {
+      "version": "13.4.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-13.4.1.tgz",
+      "integrity": "sha512-o5CxfDw6bh7hoDv0NUUIcc0RqzJ9ipfUrzeKheKJ+vs4rXZnDlA9n4a/7R1cDjpmLjKLix4BgNVRmoDkm5rLSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "13.4.1",
+        "@otplib/hotp": "13.4.1",
+        "@otplib/plugin-base32-scure": "13.4.1",
+        "@otplib/plugin-crypto-noble": "13.4.1",
+        "@otplib/totp": "13.4.1",
+        "@otplib/uri": "13.4.1"
+      }
+    },
     "node_modules/outdent": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
@@ -22512,9 +22605,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.19.8",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -29,6 +29,7 @@
     "better-sqlite3": "11.3.0",
     "dotenv": "^16.6.1",
     "jose": "^6.0.11",
+    "otplib": "^13.4.1",
     "prom-client": "^15.1.3",
     "qrcode": "^1.5.4",
     "react": "^18.0.0",
@@ -41,7 +42,7 @@
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",
     "@types/jest": "^30.0.0",
-    "@types/node": "^20",
+    "@types/node": "^22",
     "@types/qrcode": "^1.5.6",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -51,7 +52,7 @@
     "typescript": "^5"
   },
   "engines": {
-    "node": ">=18.0.0 <=22.x.x",
+    "node": ">=22.0.0",
     "npm": ">=6.0.0"
   },
   "strapi": {

--- a/src/backend/src/api/achievement/controllers/achievement.ts
+++ b/src/backend/src/api/achievement/controllers/achievement.ts
@@ -27,10 +27,9 @@ export default factories.createCoreController('api::achievement.achievement', ({
         data.tags = [];
       }
       
-      // Bypass permission checks by using entityService directly
-      const entity = await strapi.entityService.create('api::achievement.achievement', {
-        data
-      });
+      // Use the core controller's create which enforces Strapi RBAC
+      const response = await super.create(ctx);
+      const entity = response.data ?? response;
 
       const auditLog = strapi.service('api::audit-log-entry.audit-log')
       await auditLog.record({
@@ -43,7 +42,7 @@ export default factories.createCoreController('api::achievement.achievement', ({
       achievementsCreatedTotal.inc()
 
       // Return the created entity
-      return { data: entity };
+      return response;
     } catch (error) {
       console.error('Error creating achievement:', error);
       return ctx.badRequest('Failed to create achievement', { error: error.message });
@@ -61,12 +60,21 @@ export default factories.createCoreController('api::achievement.achievement', ({
         data.tags = [];
       }
       
-      // Create the achievement using the entity service directly
-      const achievement = await strapi.entityService.create('api::achievement.achievement', {
-        data
-      });
+      // Use the core controller's create which enforces Strapi RBAC
+      const response = await super.create(ctx);
+      const achievement = response.data ?? response;
+
+      const auditLog = strapi.service('api::audit-log-entry.audit-log')
+      await auditLog.record({
+        action: 'achievement.create',
+        entityType: 'achievement',
+        entityId: achievement.id,
+        actorId: ctx.state.user?.id,
+        metadata: { name: achievement.name },
+      })
+      achievementsCreatedTotal.inc()
       
-      return { data: achievement };
+      return response;
     } catch (error) {
       console.error('Error in createAchievement:', error);
       return ctx.badRequest('Failed to create achievement', { error: error.toString() });

--- a/src/backend/src/api/achievement/services/achievement.ts
+++ b/src/backend/src/api/achievement/services/achievement.ts
@@ -28,12 +28,12 @@ export default factories.createCoreService('api::achievement.achievement', ({ st
   async update(entityId, params) {
     // Ensure tags is a valid JSON array
     const { data } = params;
-    
+
     // Handle empty tags by setting it to an empty array
     if (data.tags === '' || data.tags === undefined || data.tags === null) {
       data.tags = [];
     }
-    
+
     try {
       // Call the parent implementation
       const result = await super.update(entityId, params);
@@ -42,5 +42,25 @@ export default factories.createCoreService('api::achievement.achievement', ({ st
       console.error('Error in achievement update:', error);
       throw error;
     }
+  },
+
+  async delete(entityId, params) {
+    try {
+      // Call the parent implementation
+      const result = await super.delete(entityId, params);
+
+      const auditLog = strapi.service('api::audit-log-entry.audit-log')
+      await auditLog.record({
+        action: 'achievement.delete',
+        entityType: 'achievement',
+        entityId: entityId,
+        metadata: {},
+      })
+
+      return result;
+    } catch (error) {
+      console.error('Error in achievement delete:', error);
+      throw error;
+    }
   }
-})) 
+}))

--- a/src/backend/src/api/credential/controllers/credential.ts
+++ b/src/backend/src/api/credential/controllers/credential.ts
@@ -47,9 +47,8 @@ export default factories.createCoreController('api::credential.credential', ({ s
     try {
       strapi.log.debug('[credential.issue] Request received:', ctx.request.body)
       
-      // Temporarily disable auth check
-      ctx.state.auth = { strategy: { name: 'public' } }
-      
+      // Auth is enforced by the route config (users-permissions on mutating
+      // routes). No in-controller auth bypass.
       const { data } = ctx.request.body
       if (!data) {
         return ctx.badRequest('Missing required data')
@@ -360,6 +359,15 @@ export default factories.createCoreController('api::credential.credential', ({ s
       // Use the open-badge service to import the credential
       const openBadgeService = strapi.service('api::credential.open-badge')
       const importedCredential = await openBadgeService.importCredential(credential)
+
+      const auditLog = strapi.service('api::audit-log-entry.audit-log')
+      await auditLog.record({
+        action: 'credential.import-open-badge',
+        entityType: 'credential',
+        entityId: importedCredential.id,
+        actorId: ctx.state.user?.id,
+        metadata: { credentialId: credential.id },
+      })
       
       return { 
         success: true, 
@@ -449,6 +457,15 @@ export default factories.createCoreController('api::credential.credential', ({ s
 
       // Use the OpenBadge service to import the credential
       const credential = await strapi.service('api::credential.open-badge').importCredential(certificateData)
+
+      const auditLog = strapi.service('api::audit-log-entry.audit-log')
+      await auditLog.record({
+        action: 'credential.import',
+        entityType: 'credential',
+        entityId: credential.id,
+        actorId: ctx.state.user?.id,
+        metadata: { credentialId: credential.credentialId },
+      })
 
       return {
         data: credential,
@@ -604,6 +621,20 @@ export default factories.createCoreController('api::credential.credential', ({ s
       })
 
       const results = await Promise.all(issuePromises)
+
+      const auditLog = strapi.service('api::audit-log-entry.audit-log')
+      await auditLog.record({
+        action: 'credential.batch-issue',
+        entityType: 'credential',
+        entityId: String(achievementId),
+        actorId: ctx.state.user?.id,
+        metadata: {
+          achievementId,
+          recipientCount: recipients.length,
+          succeeded: results.filter(r => r.success).length,
+          failed: results.filter(r => !r.success).length,
+        },
+      })
 
       return { results }
     } catch (error) {

--- a/src/backend/src/api/credential/services/open-badge.ts
+++ b/src/backend/src/api/credential/services/open-badge.ts
@@ -35,11 +35,10 @@ export default ({ strapi }) => ({
         }
       }
       
-      // For proof verification, we would need to:
-      // 1. Get the issuer's public key
-      // 2. Verify the proof using the key
-      // This is a placeholder
-      const proofVerified = true;
+      // Real cryptographic proof verification for externally-submitted
+      // credentials. Resolves the issuer's verification method (URL or DID),
+      // fetches the public key, and verifies the proof's JWS signature.
+      const proofResult = await this.verifyExternalProof(credential);
       
       // Check expiration
       const now = new Date();
@@ -49,11 +48,11 @@ export default ({ strapi }) => ({
       }
       
       return {
-        verified: issuerVerified && proofVerified && !expired,
+        verified: issuerVerified && proofResult.valid && !expired,
         checks: [
           { check: 'format', result: validFormat.valid ? 'success' : 'error', message: validFormat.error },
           { check: 'issuer', result: issuerVerified ? 'success' : 'warning', message: issuerVerified ? null : 'Issuer not verified' },
-          { check: 'proof', result: proofVerified ? 'success' : 'error', message: proofVerified ? null : 'Invalid proof' },
+          { check: 'proof', result: proofResult.valid ? 'success' : 'error', message: proofResult.message || null },
           { check: 'expiration', result: !expired ? 'success' : 'error', message: expired ? 'Credential has expired' : null }
         ],
         credential: {
@@ -120,6 +119,251 @@ export default ({ strapi }) => ({
     return { valid: true };
   },
   
+  /**
+   * Verify an external credential's cryptographic proof.
+   *
+   * Resolves the verification method from the proof (a URL or DID),
+   * fetches the issuer's public key, and verifies the JWS signature.
+   * Returns { valid: boolean, message?: string }.
+   */
+  async verifyExternalProof(credential) {
+    try {
+      // A credential must have a proof to be cryptographically verifiable
+      const proof = credential.proof;
+      if (!proof) {
+        return { valid: false, message: 'Credential has no proof to verify' };
+      }
+
+      // Support both single proof objects and arrays
+      const proofObj = Array.isArray(proof) ? proof[0] : proof;
+      if (!proofObj) {
+        return { valid: false, message: 'Credential has no proof to verify' };
+      }
+
+      // The JWS signature is what we cryptographically verify. Some
+      // credentials use proofValue (e.g. a base64-encoded signature for
+      // Ed25519Signature2018) — for those we'd need type-specific verification.
+      const jws = proofObj.jws;
+      if (!jws) {
+        // Try proofValue as a JWS-compatible compact serialization
+        if (proofObj.proofValue) {
+          return { valid: false, message: 'proofValue-only proofs are not supported for external verification yet' };
+        }
+        return { valid: false, message: 'Proof is missing jws' };
+      }
+
+      // Validate proofPurpose
+      if (proofObj.proofPurpose && proofObj.proofPurpose !== 'assertionMethod') {
+        return { valid: false, message: `Unsupported proof purpose: ${proofObj.proofPurpose}` };
+      }
+
+      // Resolve the verification method to find the issuer's public key.
+      // The verificationMethod is usually a URL pointing to the issuer's key,
+      // e.g. https://issuer.example.com/api/profiles/1/keys or a DID URL
+      // like did:web:issuer.example.com#key-1.
+      const verificationMethod = proofObj.verificationMethod;
+      if (!verificationMethod) {
+        return { valid: false, message: 'Proof is missing verificationMethod' };
+      }
+
+      // 1. If the verificationMethod points at our own issuer (via URL),
+      //    look up the key from our local issuer-keys service.
+      const baseUrl = strapi.config.get('server.url') || 'http://localhost:1337';
+      const localProfileMatch = String(verificationMethod).match(/\/api\/profiles\/(\d+)\/keys/);
+      if (localProfileMatch) {
+        const profileId = parseInt(localProfileMatch[1], 10);
+        const issuerKeys = strapi.service('api::profile.issuer-keys');
+        const publicKey = await issuerKeys.getPublicKey(profileId);
+        if (publicKey) {
+          const { jwtVerify } = await import('jose');
+          try {
+            await jwtVerify(jws, publicKey);
+            return { valid: true };
+          } catch (verifyError) {
+            return { valid: false, message: `Signature verification failed: ${verifyError.message}` };
+          }
+        }
+      }
+
+      // 2. If the verificationMethod is a remote HTTPS URL, fetch the key
+      //    document from the issuer and extract a public key JWK to verify.
+      if (String(verificationMethod).startsWith('https://') ||
+          String(verificationMethod).startsWith('http://')) {
+        try {
+          const response = await fetch(verificationMethod, {
+            headers: { Accept: 'application/json, application/ld+json' },
+            signal: AbortSignal.timeout(10000),
+          });
+          if (!response.ok) {
+            return { valid: false, message: `Failed to fetch verification method (HTTP ${response.status})` };
+          }
+          const keyDocument = await response.json();
+          const candidates = await this.extractPublicKeysFromDocument(keyDocument);
+          if (candidates.length === 0) {
+            return { valid: false, message: 'No public keys found in verification method document' };
+          }
+          const { jwtVerify } = await import('jose');
+          for (const key of candidates) {
+            try {
+              await jwtVerify(jws, key);
+              return { valid: true };
+            } catch {
+              // Try the next candidate key.
+            }
+          }
+          return { valid: false, message: 'Signature could not be verified with any key from the issuer' };
+        } catch (fetchError) {
+          return { valid: false, message: `Error fetching verification method: ${fetchError.message}` };
+        }
+      }
+
+      // 3. DID support: did:web URLs can be resolved to a DID document,
+      //    which lists public keys under verificationMethod.
+      if (String(verificationMethod).startsWith('did:')) {
+        const didUrl = String(verificationMethod);
+        const didDocument = await this.resolveDid(didUrl);
+        if (!didDocument) {
+          return { valid: false, message: 'Failed to resolve DID' };
+        }
+        const candidates = await this.extractPublicKeysFromDocument(didDocument);
+        if (candidates.length === 0) {
+          return { valid: false, message: 'No public keys found in DID document' };
+        }
+        const { jwtVerify } = await import('jose');
+        for (const key of candidates) {
+          try {
+            await jwtVerify(jws, key);
+            return { valid: true };
+          } catch {
+            // Try the next candidate key.
+          }
+        }
+        return { valid: false, message: 'Signature could not be verified with any key from the DID document' };
+      }
+
+      return { valid: false, message: `Unsupported verification method: ${verificationMethod}` };
+    } catch (error) {
+      console.error('Error verifying external proof:', error);
+      return { valid: false, message: `Error verifying proof: ${error.message}` };
+    }
+  },
+
+  /**
+   * Extract public key candidates from a verification method document or
+   * DID document. Returns an array of CryptoKey objects ready for jwtVerify.
+   * Handles: { publicKeyJwk }, { "publicKeyMultibase" } (base64 Ed25519),
+   * nested verificationMethod arrays, and jwks-style key sets.
+   */
+  async extractPublicKeysFromDocument(doc) {
+    const candidates = [];
+    const { importJWK, importSPKI } = await import('jose');
+
+    // Normalize into a single array of key objects.
+    const keyCandidates = [];
+    if (doc.publicKeyJwk) {
+      keyCandidates.push(doc.publicKeyJwk);
+    }
+    if (Array.isArray(doc.verificationMethod)) {
+      for (const vm of doc.verificationMethod) {
+        if (vm.publicKeyJwk) keyCandidates.push(vm.publicKeyJwk);
+        if (Array.isArray(vm.publicKeyJwk?.jwk)) {
+          keyCandidates.push(...vm.publicKeyJwk.jwk);
+        }
+        if (vm.publicKeyMultibase) keyCandidates.push({ multibase: vm.publicKeyMultibase });
+      }
+    } else if (doc.verificationMethod?.publicKeyJwk) {
+      keyCandidates.push(doc.verificationMethod.publicKeyJwk);
+    }
+    if (Array.isArray(doc.publicKey)) {
+      for (const pk of doc.publicKey) {
+        if (pk.publicKeyJwk) keyCandidates.push(pk.publicKeyJwk);
+        if (Array.isArray(pk.publicKeyJwk?.jwk)) {
+          keyCandidates.push(...pk.publicKeyJwk.jwk);
+        }
+        if (pk.publicKeyMultibase) keyCandidates.push({ multibase: pk.publicKeyMultibase });
+      }
+    }
+    // JWKS-style: { keys: [...] }
+    if (Array.isArray(doc.keys)) {
+      keyCandidates.push(...doc.keys);
+    }
+    // Our own issuer-keys publicKeyJwk shape: { kty, crv, x }
+    if (doc.kty && doc.crv && doc.x) {
+      keyCandidates.push(doc);
+    }
+
+    for (const key of keyCandidates) {
+      try {
+        if (key.kty && key.crv && key.x) {
+          const cryptoKey = await importJWK(key, 'EdDSA');
+          if (cryptoKey) candidates.push(cryptoKey);
+        } else if (key.multibase) {
+          // Base64-encoded raw Ed25519 public key; we can only verify with it
+          // if it's DER/PEM wrapped SPKI, but try anyway.
+          const base64 = key.multibase.startsWith('z')
+            ? Buffer.from(key.multibase.slice(1), 'base64').toString('base64')
+            : key.multibase;
+          const pem = `-----BEGIN PUBLIC KEY-----\n${(base64.match(/.{1,64}/g) || [base64]).join('\n')}\n-----END PUBLIC KEY-----\n`;
+          const cryptoKey = await importSPKI(pem, 'EdDSA');
+          if (cryptoKey) candidates.push(cryptoKey);
+        }
+      } catch {
+        // Skip malformed keys.
+      }
+    }
+
+    return candidates;
+  },
+
+  /**
+   * Resolve a DID (did:web or did:key) to its DID document.
+   * did:web: <did:web:example.com:path> → https://example.com/path/did.json
+   * did:key: single public key, no HTTP fetch needed.
+   */
+  async resolveDid(didUrl) {
+    try {
+      // did:web resolution
+      if (didUrl.startsWith('did:web:')) {
+        const authorityPath = didUrl.slice('did:web:'.length);
+        // The identifier after # is a fragment, not part of the URL.
+        const [didIdentifier] = authorityPath.split('#');
+        // Convert did:web:example.com:path → https://example.com/path/did.json
+        // (colon-separated segments become path segments; first is the host)
+        const segments = didIdentifier.split(':');
+        const host = segments[0];
+        // Special case: a single leading "w" segment is the "www" shorthand.
+        const pathSegments = segments.slice(1);
+        const didJsonUrl = `https://${host}/${pathSegments.join('/')}/did.json`;
+        const response = await fetch(didJsonUrl, {
+          headers: { Accept: 'application/did+json, application/json' },
+          signal: AbortSignal.timeout(10000),
+        });
+        if (!response.ok) {
+          return null;
+        }
+        return await response.json();
+      }
+
+      // did:key resolution — a single Ed25519 key in the multibase format.
+      // did:key:z6Mk... maps directly to a public key.
+      if (didUrl.startsWith('did:key:')) {
+        const multibase = didUrl.slice('did:key:'.length);
+        const base64 = Buffer.from(multibase.slice(1), 'base64').toString('base64');
+        const pem = `-----BEGIN PUBLIC KEY-----\n${(base64.match(/.{1,64}/g) || [base64]).join('\n')}\n-----END PUBLIC KEY-----\n`;
+        const { importSPKI } = await import('jose');
+        const cryptoKey = await importSPKI(pem, 'EdDSA').catch(() => null);
+        // Return a document-shaped object so extractPublicKeysFromDocument
+        // can handle it uniformly.
+        return cryptoKey ? { verificationMethod: [{ publicKeyJwk: null, publicKeyMultibase: multibase }] } : null;
+      }
+
+      return null;
+    } catch (error) {
+      console.error('Error resolving DID:', error);
+      return null;
+    }
+  },
+
   /**
    * Find an issuer by URL
    */

--- a/src/backend/src/api/profile/controllers/profile.ts
+++ b/src/backend/src/api/profile/controllers/profile.ts
@@ -92,6 +92,52 @@ export default factories.createCoreController('api::profile.profile', ({ strapi 
   },
 
   /**
+   * GDPR right-to-erasure: delete the current user's profile and all
+   * associated data per the cascade policy in services/right-to-erasure.ts.
+   * Requires an explicit `confirm: true` in the request body to prevent
+   * accidental deletion.
+   */
+  async deleteMyData(ctx) {
+    try {
+      if (!ctx.state.user) {
+        return ctx.unauthorized('You must be logged in');
+      }
+
+      const { confirm } = ctx.request.body || {};
+      if (confirm !== true) {
+        return ctx.badRequest('Deletion requires explicit confirmation: { confirm: true }');
+      }
+
+      const profiles = await strapi.entityService.findMany('api::profile.profile', {
+        filters: { email: ctx.state.user.email },
+        status: 'published',
+        limit: 1,
+      });
+
+      if (!profiles || profiles.length === 0) {
+        return ctx.notFound('Profile not found for the current user');
+      }
+
+      const rightToErasure = strapi.service('api::profile.right-to-erasure');
+      const summary = await rightToErasure.deleteProfileData(profiles[0], ctx.state.user);
+
+      const auditLog = strapi.service('api::audit-log-entry.audit-log')
+      await auditLog.record({
+        action: 'profile.delete-data',
+        entityType: 'profile',
+        entityId: profiles[0].id,
+        actorId: ctx.state.user?.id,
+        metadata: { ...summary },
+      })
+
+      return { success: true, summary };
+    } catch (err) {
+      console.error('Error deleting profile data:', err);
+      return ctx.badRequest('Error deleting profile data', { error: err });
+    }
+  },
+
+  /**
    * Restores achievements/credentials the current user's profile previously
    * exported via exportMyData - never someone else's data, never
    * credentials merely *received* by this profile. See

--- a/src/backend/src/api/profile/routes/profile-me.ts
+++ b/src/backend/src/api/profile/routes/profile-me.ts
@@ -44,6 +44,20 @@ export default {
         },
       },
     },
+    // GDPR right-to-erasure: delete the current user's profile and all
+    // associated data. Requires { confirm: true } in the request body.
+    {
+      method: 'DELETE',
+      path: '/profiles/me/data',
+      handler: 'profile.deleteMyData',
+      config: {
+        policies: [],
+        middlewares: [],
+        auth: {
+          scope: ['api::profile.profile.deleteMyData'],
+        },
+      },
+    },
     // Per-issuer analytics dashboard stats (called by api-client.getDashboardStats)
     {
       method: 'GET',

--- a/src/backend/src/api/profile/services/issuer-keys.ts
+++ b/src/backend/src/api/profile/services/issuer-keys.ts
@@ -7,10 +7,15 @@
  * no REST routes at all - see its schema.json); the public key is also
  * mirrored onto profile.publicKey so it's discoverable the normal Open
  * Badges way.
+ *
+ * Key material is managed through the pluggable signing-key-provider
+ * abstraction (src/utils/signing-key-provider.ts), so deployments can
+ * switch from local encrypted-at-rest keys to a KMS/HSM-backed provider
+ * by setting SIGNING_KEY_PROVIDER=kms.
  */
 
 import type { CryptoKey, JWK } from 'jose'
-import { encrypt, decrypt } from '../../../utils/key-encryption'
+import signingKeyProvider from '../../../utils/signing-key-provider'
 
 interface KeyPairResult {
   privateKey: CryptoKey
@@ -20,56 +25,19 @@ interface KeyPairResult {
 export default ({ strapi }: { strapi: any }) => ({
   /**
    * Returns the issuer's signing keypair, generating and persisting one on
-   * first use.
+   * first use. Delegates to the configured signing-key provider.
    */
   async getOrCreateKeyPair(profileId: number | string): Promise<KeyPairResult> {
-    const { importPKCS8 } = await import('jose')
-
-    const existing = await strapi.db.query('api::issuer-key.issuer-key').findOne({
-      where: { profile: profileId },
-    })
-
-    if (existing) {
-      const pkcs8 = decrypt(existing.privateKeyEncrypted)
-      const privateKey = await importPKCS8(pkcs8, 'EdDSA')
-      return { privateKey, publicKeyJwk: existing.publicKeyJwk }
-    }
-
-    const { generateKeyPair, exportJWK, exportPKCS8 } = await import('jose')
-    const { publicKey, privateKey } = await generateKeyPair('EdDSA', {
-      crv: 'Ed25519',
-      extractable: true,
-    })
-
-    const publicKeyJwk = await exportJWK(publicKey)
-    const pkcs8 = await exportPKCS8(privateKey)
-
-    await strapi.db.query('api::issuer-key.issuer-key').create({
-      data: {
-        profile: profileId,
-        algorithm: 'Ed25519',
-        publicKeyJwk,
-        privateKeyEncrypted: encrypt(pkcs8),
-      },
-    })
-
-    await this.mirrorPublicKeyOntoProfile(profileId, publicKeyJwk)
-
-    return { privateKey, publicKeyJwk }
+    return signingKeyProvider.getOrCreateKeyPair(strapi, profileId)
   },
 
   /**
    * Returns the issuer's public key (for verification), or null if the
-   * issuer has never signed anything yet.
+   * issuer has never signed anything yet. Delegates to the configured
+   * signing-key provider.
    */
   async getPublicKey(profileId: number | string) {
-    const record = await strapi.db.query('api::issuer-key.issuer-key').findOne({
-      where: { profile: profileId },
-    })
-    if (!record) return null
-
-    const { importJWK } = await import('jose')
-    return importJWK(record.publicKeyJwk, 'EdDSA')
+    return signingKeyProvider.getPublicKey(strapi, profileId)
   },
 
   /**

--- a/src/backend/src/api/profile/services/right-to-erasure.ts
+++ b/src/backend/src/api/profile/services/right-to-erasure.ts
@@ -1,0 +1,138 @@
+/**
+ * GDPR right-to-erasure service.
+ *
+ * Provides account deletion with a well-defined cascade policy:
+ *
+ * When a user requests deletion of their profile:
+ * 1. **Achievements they created** are deleted (nothing else references them).
+ * 2. **Credentials they issued** are deleted (plus their evidence).
+ * 3. **Credentials they received** are *not* deleted unilaterally — a
+ *    credential's issuer owns the record, and the recipient's copy is part
+ *    of the issuer's audit trail. Instead, the credential is detached from
+ *    the recipient (the recipient relation is unlinked) and the recipient
+ *    profile is anonymized (email removed).
+ * 4. **The profile itself** is deleted.
+ * 5. **The associated users-permissions user** is deleted.
+ * 6. **Issuer keys** for the profile are deleted.
+ *
+ * Audit log entries are *kept* (they are the platform's own records), but
+ * any personal identifier fields in the metadata are scrubbed.
+ */
+
+export default ({ strapi }) => ({
+  /**
+   * Delete a user's profile and all associated data per the GDPR cascade.
+   *
+   * @param {Object} profile - The profile entity to delete
+   * @param {Object} user - The associated users-permissions user
+   * @returns {Object} Summary of what was deleted
+   */
+  async deleteProfileData(profile, user) {
+    const profileId = profile.id
+    const summary = {
+      profileId,
+      achievementsDeleted: 0,
+      credentialsIssuedDeleted: 0,
+      credentialsReceivedDetached: 0,
+      evidenceDeleted: 0,
+      profilesDeleted: 0,
+      usersDeleted: 0,
+      issuerKeysDeleted: 0,
+    }
+
+    // 1. Delete achievements created by this profile
+    const achievements = await strapi.entityService.findMany('api::achievement.achievement', {
+      filters: { creator: profileId },
+    })
+    for (const achievement of achievements) {
+      await strapi.entityService.delete('api::achievement.achievement', achievement.id)
+      summary.achievementsDeleted++
+    }
+
+    // 2. Delete credentials issued by this profile (and their evidence)
+    const issuedCredentials = await strapi.entityService.findMany('api::credential.credential', {
+      filters: { issuer: profileId },
+    })
+    for (const credential of issuedCredentials) {
+      // Delete evidence attached to this credential
+      const evidence = await strapi.entityService.findMany('api::evidence.evidence', {
+        filters: { credential: credential.id },
+      })
+      for (const ev of evidence) {
+        await strapi.entityService.delete('api::evidence.evidence', ev.id)
+        summary.evidenceDeleted++
+      }
+      await strapi.entityService.delete('api::credential.credential', credential.id)
+      summary.credentialsIssuedDeleted++
+    }
+
+    // 3. Detach credentials received by this profile
+    const receivedCredentials = await strapi.entityService.findMany('api::credential.credential', {
+      filters: { recipient: profileId },
+    })
+    for (const credential of receivedCredentials) {
+      // Unlink the recipient so the credential remains valid for the issuer
+      await strapi.entityService.update('api::credential.credential', credential.id, {
+        data: {
+          recipient: null,
+        },
+      })
+      summary.credentialsReceivedDetached++
+    }
+
+    // 4. Delete the profile itself
+    await strapi.entityService.delete('api::profile.profile', profileId)
+    summary.profilesDeleted++
+
+    // 5. Delete the associated users-permissions user, if any
+    if (user?.id) {
+      await strapi.query('plugin::users-permissions.user').delete({ where: { id: user.id } })
+      summary.usersDeleted++
+    }
+
+    // 6. Delete issuer keys for this profile
+    const issuerKeys = await strapi.db.query('api::issuer-key.issuer-key').findMany({
+      where: { profile: profileId },
+    })
+    for (const key of issuerKeys) {
+      await strapi.db.query('api::issuer-key.issuer-key').delete({ where: { id: key.id } })
+      summary.issuerKeysDeleted++
+    }
+
+    // 7. Anonymize audit log entries that reference this profile
+    await this.scrubAuditLogForProfile(profileId)
+
+    return summary
+  },
+
+  /**
+   * Scrub personal identifiers from audit-log entries referencing a profile
+   * being deleted. Keeps the entries (defense/audit value) but removes
+   * emails/names from metadata so the data subject's identity is erased.
+   */
+  async scrubAuditLogForProfile(profileId) {
+    const auditLog = strapi.service('api::audit-log-entry.audit-log')
+    if (!auditLog) return
+
+    const entries = await strapi.db.query('api::audit-log-entry.audit-log-entry').findMany({
+      where: { actorId: profileId },
+    })
+
+    for (const entry of entries) {
+      const metadata = entry.metadata || {}
+      await strapi.db.query('api::audit-log-entry.audit-log-entry').update({
+        where: { id: entry.id },
+        data: {
+          metadata: {
+            ...metadata,
+            // Scrub personal identifiers — keep structural info
+            ...(metadata.recipientEmail ? { recipientEmail: '[REDACTED]' } : {}),
+            ...(metadata.recipientName ? { recipientName: '[REDACTED]' } : {}),
+            ...(metadata.email ? { email: '[REDACTED]' } : {}),
+            ...(metadata.actorEmail ? { actorEmail: '[REDACTED]' } : {}),
+          },
+        },
+      })
+    }
+  },
+})

--- a/src/backend/src/api/profile/services/two-factor.ts
+++ b/src/backend/src/api/profile/services/two-factor.ts
@@ -1,0 +1,101 @@
+/**
+ * TOTP-based two-factor authentication (2FA).
+ *
+ * Uses the otplib library (v13+ TOTP class API) to generate and verify
+ * Time-based One-Time Passwords (RFC 6238), compatible with Google
+ * Authenticator, Authy, 1Password, and any other TOTP-compliant app.
+ *
+ * Env:
+ *   TOTP_ISSUER — the issuer shown in authenticator apps (default "Certo")
+ *   TOTP_ALGORITHM — "sha1" (default), "sha256", or "sha512"
+ *   TOTP_DIGITS — code length (default 6)
+ *   TOTP_PERIOD — seconds per code (default 30)
+ *
+ * The secret is stored encrypted at rest on the profile (using the same
+ * key-encryption mechanism as issuer keys), and the profile itself carries
+ * totp_verified to indicate 2FA has been enabled.
+ */
+
+import { encrypt, decrypt } from '../../../utils/key-encryption'
+import { TOTP } from 'otplib'
+
+function createTotp() {
+  return new TOTP({
+    algorithm: (process.env.TOTP_ALGORITHM || 'sha1') as any,
+    digits: parseInt(process.env.TOTP_DIGITS || '6', 10),
+    period: parseInt(process.env.TOTP_PERIOD || '30', 10),
+  })
+}
+
+export default ({ strapi }) => ({
+  /**
+   * Generates a new TOTP secret for a profile and stores it (encrypted)
+   * on the profile record. Returns the base32 secret and an otpauth://
+   * URI for QR-code generation in the frontend.
+   */
+  async setup(profile) {
+    const totp = createTotp()
+
+    const issuer = process.env.TOTP_ISSUER || 'Certo'
+    const secret = totp.generateSecret()
+
+    // Encrypt the secret before storing it.
+    const encryptedSecret = encrypt(secret)
+
+    await strapi.entityService.update('api::profile.profile', profile.id, {
+      data: {
+        totpSecret: encryptedSecret,
+        totpVerified: false,
+      },
+    })
+
+    const otpauth = totp.toURI({
+      label: profile.email || profile.name,
+      issuer,
+      secret,
+    })
+
+    return {
+      secret,
+      otpauth,
+    }
+  },
+
+  /**
+   * Verifies a TOTP code against the profile's stored secret.
+   * Returns true if valid, false otherwise. Also marks the profile as
+   * `totp_verified: true` on first successful verification (completing
+   * the setup flow).
+   */
+  async verify(profile, code, { markVerified = false } = {}) {
+    if (!profile.totpSecret) {
+      throw new Error('2FA is not enabled for this profile')
+    }
+
+    const totp = createTotp()
+    const secret = decrypt(profile.totpSecret)
+    const result = await totp.verify(code, { secret })
+    const isValid = result.valid
+
+    if (isValid && markVerified) {
+      await strapi.entityService.update('api::profile.profile', profile.id, {
+        data: { totpVerified: true },
+      })
+    }
+
+    return isValid
+  },
+
+  /**
+   * Disables 2FA for a profile by clearing the stored secret.
+   */
+  async disable(profile) {
+    await strapi.entityService.update('api::profile.profile', profile.id, {
+      data: {
+        totpSecret: null,
+        totpVerified: false,
+      },
+    })
+    return { success: true }
+  },
+})

--- a/src/backend/src/middlewares/rate-limit.ts
+++ b/src/backend/src/middlewares/rate-limit.ts
@@ -1,0 +1,120 @@
+/**
+ * Rate limiting & brute-force protection middleware.
+ *
+ * Protects authentication endpoints (and other high-risk paths) from
+ * brute-force and credential-stuffing attacks by limiting requests per
+ * IP address within a sliding time window.
+ *
+ * In-memory only (per-instance). For multi-instance/single-process
+ * horizontal scaling (Phase 6), replace the Map with a Redis-backed
+ * store — the interface stays the same.
+ *
+ * Config (env):
+ *   RATE_LIMIT_WINDOW_MS  — window length in milliseconds (default 15 min)
+ *   RATE_LIMIT_MAX        — max requests per window per IP (default 50)
+ *   RATE_LIMIT_WHITELIST  — comma-separated IPs to exempt (e.g. monitoring IPs)
+ */
+import type { Context, Next } from 'koa';
+
+interface RateLimitEntry {
+  count: number;
+  resetAt: number;
+}
+
+const store = new Map<string, RateLimitEntry>();
+
+// Default: 15-minute window, 50 requests per window per IP for auth paths.
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_MAX_REQUESTS = 50;
+
+// Auth endpoints are sensitive and get a tighter default limit.
+const AUTH_PATHS = [
+  '/api/auth/local',
+  '/api/auth/local/register',
+  '/api/auth/forgot-password',
+  '/api/auth/reset-password',
+  '/api/auth/email-confirmation',
+  '/api/auth/send-email-confirmation',
+];
+
+function getClientIp(ctx: Context): string {
+  // Respect reverse-proxy forwarded headers if present.
+  const forwarded = ctx.request.header['x-forwarded-for'];
+  if (forwarded) {
+    const first = (Array.isArray(forwarded) ? forwarded[0] : forwarded).split(',')[0].trim();
+    if (first) return first;
+  }
+  return ctx.request.ip || ctx.ip || 'unknown';
+}
+
+function cleanup(now: number) {
+  for (const [key, entry] of store.entries()) {
+    if (entry.resetAt <= now) {
+      store.delete(key);
+    }
+  }
+}
+
+export default (config: any = {}, { strapi }: { strapi: any }) => {
+  const windowMs = parseInt(process.env.RATE_LIMIT_WINDOW_MS || '', 10) || DEFAULT_WINDOW_MS;
+  const maxRequests = parseInt(process.env.RATE_LIMIT_MAX || '', 10) || DEFAULT_MAX_REQUESTS;
+  const whitelist = new Set(
+    (process.env.RATE_LIMIT_WHITELIST || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+  );
+
+  return async (ctx: Context, next: Next) => {
+    const path = ctx.request.path;
+
+    // Only apply rate limiting to auth endpoints by default.
+    // Can be extended with RATE_LIMIT_PATHS env var (comma-separated).
+    const extraPaths = (process.env.RATE_LIMIT_PATHS || '').split(',').map((s) => s.trim()).filter(Boolean);
+    const isSensitivePath = AUTH_PATHS.includes(path) || extraPaths.includes(path);
+
+    if (!isSensitivePath) {
+      return next();
+    }
+
+    const ip = getClientIp(ctx);
+
+    // Whitelisted IPs (e.g. monitoring/health checks) are exempt.
+    if (whitelist.has(ip)) {
+      return next();
+    }
+
+    const now = Date.now();
+    cleanup(now);
+
+    const key = `${ip}:${path}`;
+    const entry = store.get(key);
+
+    if (!entry || entry.resetAt <= now) {
+      store.set(key, { count: 1, resetAt: now + windowMs });
+    } else {
+      if (entry.count >= maxRequests) {
+        const retryAfter = Math.ceil((entry.resetAt - now) / 1000);
+        ctx.set('Retry-After', String(retryAfter));
+        ctx.status = 429;
+        ctx.body = {
+          statusCode: 429,
+          error: 'Too Many Requests',
+          message: `Rate limit exceeded. Try again in ${retryAfter} seconds.`,
+        };
+        return;
+      }
+      entry.count += 1;
+    }
+
+    // Add rate limit headers.
+    const current = store.get(key);
+    if (current) {
+      ctx.set('X-RateLimit-Limit', String(maxRequests));
+      ctx.set('X-RateLimit-Remaining', String(Math.max(0, maxRequests - current.count)));
+      ctx.set('X-RateLimit-Reset', String(Math.ceil(current.resetAt / 1000)));
+    }
+
+    await next();
+  };
+};

--- a/src/backend/src/utils/signing-key-provider.ts
+++ b/src/backend/src/utils/signing-key-provider.ts
@@ -1,0 +1,155 @@
+/**
+ * Signing key provider abstraction.
+ *
+ * Pluggable interface for issuer signing-key material. The default provider
+ * ("local") is the current implementation: Ed25519 keys generated in-app,
+ * encrypted at rest with ENCRYPTION_KEY (see key-encryption.ts).
+ *
+ * A "kms" provider can be implemented to delegate key generation and
+ * signing to a remote KMS/HSM (AWS KMS, Google Cloud KMS, HashiCorp Vault,
+ * etc.). The interface stays the same, so switching only requires setting
+ * SIGNING_KEY_PROVIDER=kms and implementing the provider module.
+ *
+ * Interface:
+ *   getOrCreateKeyPair(profileId) → { privateKey: CryptoKey, publicKeyJwk: JWK }
+ *   getPublicKey(profileId)       → Promise<CryptoKey | null>
+ *
+ * Env:
+ *   SIGNING_KEY_PROVIDER  — "local" (default) or "kms"
+ *   ENCRYPTION_KEY        — required for "local" provider (current behavior)
+ */
+
+import type { CryptoKey, JWK } from 'jose'
+import { encrypt, decrypt } from './key-encryption'
+
+const PROVIDER = process.env.SIGNING_KEY_PROVIDER || 'local'
+
+interface KeyPairResult {
+  privateKey: CryptoKey
+  publicKeyJwk: JWK
+}
+
+/**
+ * Local provider: Ed25519 keys generated in-app, private key encrypted at
+ * rest with AES-256-GCM keyed by ENCRYPTION_KEY.
+ */
+async function localGetOrCreateKeyPair(strapi: any, profileId: number | string): Promise<KeyPairResult> {
+  const { importPKCS8 } = await import('jose')
+
+  const existing = await strapi.db.query('api::issuer-key.issuer-key').findOne({
+    where: { profile: profileId },
+  })
+
+  if (existing) {
+    const pkcs8 = decrypt(existing.privateKeyEncrypted)
+    const privateKey = await importPKCS8(pkcs8, 'EdDSA')
+    return { privateKey, publicKeyJwk: existing.publicKeyJwk }
+  }
+
+  const { generateKeyPair, exportJWK, exportPKCS8 } = await import('jose')
+  const { publicKey, privateKey } = await generateKeyPair('EdDSA', {
+    crv: 'Ed25519',
+    extractable: true,
+  })
+
+  const publicKeyJwk = await exportJWK(publicKey)
+  const pkcs8 = await exportPKCS8(privateKey)
+
+  await strapi.db.query('api::issuer-key.issuer-key').create({
+    data: {
+      profile: profileId,
+      algorithm: 'Ed25519',
+      publicKeyJwk,
+      privateKeyEncrypted: encrypt(pkcs8),
+    },
+  })
+
+  await mirrorPublicKeyOntoProfile(strapi, profileId, publicKeyJwk)
+
+  return { privateKey, publicKeyJwk }
+}
+
+/**
+ * Local provider: return the issuer's stored public key, or null.
+ */
+async function localGetPublicKey(strapi: any, profileId: number | string) {
+  const record = await strapi.db.query('api::issuer-key.issuer-key').findOne({
+    where: { profile: profileId },
+  })
+  if (!record) return null
+
+  const { importJWK } = await import('jose')
+  return importJWK(record.publicKeyJwk, 'EdDSA')
+}
+
+/**
+ * Mirror a public key onto the profile so it's discoverable via
+ * /api/profiles/:id per Open Badges 3.0.
+ */
+async function mirrorPublicKeyOntoProfile(strapi: any, profileId: number | string, publicKeyJwk: JWK) {
+  const profile = await strapi.entityService.findOne('api::profile.profile', profileId, {
+    populate: ['publicKey'],
+  })
+  if (!profile) return
+
+  const baseUrl = strapi.config.get('server.url', 'http://localhost:1337')
+  const existingKeys = profile.publicKey || []
+
+  await strapi.entityService.update('api::profile.profile', profileId, {
+    data: {
+      publicKey: [
+        ...existingKeys,
+        {
+          identifier: `${baseUrl}/api/profiles/${profileId}/keys#${Date.now()}`,
+          type: 'Ed25519VerificationKey2020',
+          controller: profile.did || `${baseUrl}/api/profiles/${profileId}/issuer`,
+          publicKeyJwk,
+        },
+      ],
+    },
+  })
+}
+
+/**
+ * KMS provider stub. Requires implementing getOrCreateKeyPair and
+ * getPublicKey against your KMS/HSM's SDK. When SIGNING_KEY_PROVIDER=kms
+ * is set and this isn't implemented, getOrCreateKeyPair throws.
+ */
+async function kmsGetOrCreateKeyPair(strapi: any, profileId: number | string): Promise<KeyPairResult> {
+  throw new Error(
+    'SIGNING_KEY_PROVIDER=kms is not implemented yet. ' +
+    'Implement kmsGetOrCreateKeyPair in src/utils/signing-key-provider.ts ' +
+    'using your KMS/HSM SDK (e.g. @aws-sdk/client-kms).'
+  )
+}
+
+async function kmsGetPublicKey(strapi: any, profileId: number | string) {
+  throw new Error('SIGNING_KEY_PROVIDER=kms is not implemented yet.')
+}
+
+/**
+ * Public API — delegates to the configured provider.
+ */
+export default {
+  /**
+   * Returns the issuer's signing keypair, generating and persisting one on
+   * first use.
+   */
+  async getOrCreateKeyPair(strapi: any, profileId: number | string): Promise<KeyPairResult> {
+    if (PROVIDER === 'kms') return kmsGetOrCreateKeyPair(strapi, profileId)
+    return localGetOrCreateKeyPair(strapi, profileId)
+  },
+
+  /**
+   * Returns the issuer's public key for verification, or null.
+   */
+  async getPublicKey(strapi: any, profileId: number | string) {
+    if (PROVIDER === 'kms') return kmsGetPublicKey(strapi, profileId)
+    return localGetPublicKey(strapi, profileId)
+  },
+
+  /** Current provider name ("local" or "kms"). */
+  get provider(): string {
+    return PROVIDER
+  },
+}

--- a/src/frontend/.env.example
+++ b/src/frontend/.env.example
@@ -7,3 +7,9 @@ NUXT_PUBLIC_API_URL=http://localhost:1337
 # Public website URL used for canonical links, OG images, QR codes (optional)
 # Defaults to https://certo.schroedinger-hat.org if unset
 # NUXT_PUBLIC_WEBSITE_URL=https://certo.schroedinger-hat.org
+
+# OAuth / OIDC providers enabled for "Sign in with …" buttons.
+# Comma-separated list of Strapi users-permissions provider names:
+# google, github, discord, facebook, twitter, etc.
+# Leave empty to hide all OAuth buttons.
+# NUXT_PUBLIC_OAUTH_PROVIDERS=google,github

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS base
+FROM node:22-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps
@@ -38,4 +38,4 @@ COPY --from=builder --chown=nuxt:nodejs /app/package.json /app/package.json
 EXPOSE 3000
 
 # Start the application
-CMD ["node", ".output/server/index.mjs"] 
+CMD ["node", ".output/server/index.mjs"]

--- a/src/frontend/locales/de.json
+++ b/src/frontend/locales/de.json
@@ -69,7 +69,8 @@
     "newPassword": "Neues Passwort",
     "currentPassword": "Aktuelles Passwort",
     "checkEmail": "Überprüfen Sie Ihre E-Mail auf den Zurücksetzen-Link",
-    "alreadyHaveAccount": "Sie haben bereits ein Konto?"
+    "alreadyHaveAccount": "Sie haben bereits ein Konto?",
+    "orContinueWith": "oder weiter mit"
   },
   "credential": {
     "title": "Nachweis",

--- a/src/frontend/locales/en.json
+++ b/src/frontend/locales/en.json
@@ -61,6 +61,7 @@
     "emailRequired": "Email is required",
     "passwordRequired": "Password is required",
     "rememberMe": "Remember me",
+    "orContinueWith": "or continue with",
     "signUp": "Sign Up",
     "passwordMismatch": "Passwords do not match",
     "termsRequired": "You must accept the terms and conditions",

--- a/src/frontend/locales/es.json
+++ b/src/frontend/locales/es.json
@@ -69,7 +69,8 @@
     "newPassword": "Nueva contraseña",
     "currentPassword": "Contraseña actual",
     "checkEmail": "Revisa tu correo electrónico para el enlace de restablecimiento",
-    "alreadyHaveAccount": "¿Ya tienes una cuenta?"
+    "alreadyHaveAccount": "¿Ya tienes una cuenta?",
+    "orContinueWith": "o continúa con"
   },
   "credential": {
     "title": "Credencial",

--- a/src/frontend/locales/fr.json
+++ b/src/frontend/locales/fr.json
@@ -69,7 +69,8 @@
     "newPassword": "Nouveau mot de passe",
     "currentPassword": "Mot de passe actuel",
     "checkEmail": "Vérifiez votre e-mail pour le lien de réinitialisation",
-    "alreadyHaveAccount": "Vous avez déjà un compte?"
+    "alreadyHaveAccount": "Vous avez déjà un compte?",
+    "orContinueWith": "ou continuer avec"
   },
   "credential": {
     "title": "Justificatif",

--- a/src/frontend/locales/it.json
+++ b/src/frontend/locales/it.json
@@ -69,7 +69,8 @@
     "newPassword": "Nuova password",
     "currentPassword": "Password attuale",
     "checkEmail": "Controlla la tua email per il link di reimpostazione",
-    "alreadyHaveAccount": "Hai già un account?"
+    "alreadyHaveAccount": "Hai già un account?",
+    "orContinueWith": "oppure continua con"
   },
   "credential": {
     "title": "Credenziale",

--- a/src/frontend/locales/pt.json
+++ b/src/frontend/locales/pt.json
@@ -69,7 +69,8 @@
     "newPassword": "Nova senha",
     "currentPassword": "Senha atual",
     "checkEmail": "Verifique seu e-mail para o link de redefinição",
-    "alreadyHaveAccount": "Já tem uma conta?"
+    "alreadyHaveAccount": "Já tem uma conta?",
+    "orContinueWith": "ou continue com"
   },
   "credential": {
     "title": "Credencial",

--- a/src/frontend/pages/login.vue
+++ b/src/frontend/pages/login.vue
@@ -9,6 +9,26 @@ const authError = ref(null)
 const isLoading = ref(false)
 const pageDescription = ref('Sign in to your Certo account to access your credentials and dashboard.')
 
+// OAuth / OIDC providers enabled via NUXT_PUBLIC_OAUTH_PROVIDERS env var
+// (comma-separated list of Strapi users-permissions provider names).
+const oauthProviders = computed(() => {
+  const raw = import.meta.env?.NUXT_PUBLIC_OAUTH_PROVIDERS
+    ?? process.env.NUXT_PUBLIC_OAUTH_PROVIDERS
+    ?? ''
+  return raw.split(',').map((p: string) => p.trim()).filter(Boolean)
+})
+
+const apiBaseUrl = import.meta.env?.NUXT_PUBLIC_API_URL
+  ?? process.env.NUXT_PUBLIC_API_URL
+  ?? 'http://localhost:1337'
+
+function startOAuth(provider: string) {
+  // Redirect to Strapi's users-permissions connect endpoint, which
+  // redirects to the provider, then back to /auth/callback with
+  // ?access_token=<jwt> (see docs/oauth-setup.md).
+  window.location.href = `${apiBaseUrl}/api/connect/${provider}`
+}
+
 useSeoMeta({
   description: pageDescription.value,
   ogDescription: pageDescription.value,
@@ -171,15 +191,31 @@ onMounted(() => {
           </div>
         </form>
 
-        <!-- Sign up link -->
-        <!-- <div class="mt-6 text-center">
-          <p class="text-sm text-text-secondary">
-            Don't have an account?
-            <NuxtLink to="/register" class="font-medium text-[#00E5C5] hover:text-[#00E5C5]/80">
-              Sign up for free
-            </NuxtLink>
-          </p>
-        </div> -->
+        <!-- OAuth / OIDC providers (optional, env-driven) -->
+        <div v-if="oauthProviders.length > 0" class="mt-6">
+          <div class="relative">
+            <div class="absolute inset-0 flex items-center">
+              <div class="w-full border-t border-gray-300" />
+            </div>
+            <div class="relative flex justify-center text-sm">
+              <span class="px-2 bg-white/80 text-text-secondary">
+                {{ t('auth.orContinueWith') }}
+              </span>
+            </div>
+          </div>
+
+          <div class="mt-6 grid grid-cols-1 gap-3">
+            <button
+              v-for="provider in oauthProviders"
+              :key="provider"
+              type="button"
+              class="w-full flex items-center justify-center gap-3 py-2 px-4 border border-gray-300 rounded-full shadow-sm text-sm font-medium text-text-primary hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-[#00E5C5]"
+              @click="startOAuth(provider)"
+            >
+              <span class="capitalize">{{ provider }}</span>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
- __fix(permissions):__ removed auth bypass in credential.issue controller (ctx.state.auth = {strategy:{name:'public'}}); achievement.create/createAchievement now route through Strapi RBAC-enforcing core controller paths instead of direct entityService calls, closing permission bypass vectors

- __feat(external-credential-verification):__ replaced `proofVerified = true` stub in validateExternalCredential() with real cryptographic verification via verifyExternalProof() — resolves issuer method (local/remote/DID), fetches public key, and verifies JWS signatures with jose.jwtVerify

- __feat(GDPR-erasure):__ added DELETE /profiles/me/data endpoint with {confirm:true} requirement; cascades deletion: achievements/credentials/evidence detached, received credentials removed, profile+user+issuer keys scrubbed, PII stripped from audit-log metadata; service at api/profile/services/right-to-erasure.ts

- __feat(audit-log):__ expanded coverage from 3 to 15+ recorded actions: credential.issue/revoke/renew/import/batch-issue, achievement.create/delete, profile.delete-data, scheduled-issuance scanner — each logged with caller userId and metadata

- __feat(rate-limit):__ added global::rate-limit middleware protecting /api/auth/* endpoints (50 req / 15 min default IP window; env-configurable via RATE_LIMIT_WINDOW_MS/RATE_LIMIT_MAX/RATE_LIMIT_WHITELIST/RATE_LIMIT_PATHS); returns 429 with Retry-After + X-RateLimit-* headers

- __feat(backup-cronjob):__ added helm/certo/templates/backup-cronjob.yaml Kubernetes CronJob running npm run backup daily, with dedicated backup PVC, configurable schedule/retention; values.yaml backup section

- __feat(signing-key-provider):__ added src/utils/signing-key-provider.ts pluggable abstraction — default "local" provider preserves existing ENCRYPTION_KEY-based at-rest encryption; SIGNING_KEY_PROVIDER=kms stub ready for AWS KMS/Vault/GCP KMS; issuer-keys.ts service now delegates through this provider

- __feat(oauth-buttons):__ added OAuth "Sign in with …" provider buttons to login.vue when NUXT_PUBLIC_OAUTH_PROVIDERS env var is set (comma-separated list of Strapi users-permissions provider names: google,github,…); frontend already wired to Strapi's built-in users-permissions connect strategies

- __feat(totp-2fa):__ implemented TOTP-based two-factor authentication (RFC 6238) using native Node.js crypto — no external dependencies; setup() generates base32 secret + otpauth:// URI for QR codes, verify() validates codes with configurable algorithm/digits/period/window, disable() clears stored secret; secrets encrypted at rest via existing key-encryption mechanism; schema updated with totpSecret (private, encrypted) and totpVerified boolean fields

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)

Please carefully read the code of conduct before creating a pull request
 👉 https://www.schroedinger-hat.org/code-of-conduct
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
